### PR TITLE
Add go/raindrops

### DIFF
--- a/lib/orchestrator/analyze_iteration.rb
+++ b/lib/orchestrator/analyze_iteration.rb
@@ -7,6 +7,7 @@ module Orchestrator
     
     ['go', 'two-fer'],
     ['go', 'hamming'],
+    ['go', 'raindrops'],
     
     ['java', 'two-fer'],
     


### PR DESCRIPTION
This needs `v0.3.0` of the `go-analyzer` running before it can be merged.

https://github.com/exercism/go-analyzer/releases